### PR TITLE
Fix: Apply critical Slither recommendations (Reentrancy, Event, Deadl…

### DIFF
--- a/smartcontract/src/Pool.sol
+++ b/smartcontract/src/Pool.sol
@@ -32,7 +32,12 @@ contract Pool is IPool, Ownable {
     // Requirement: Pool must be initialized with tokens and factory only once
     function initialize(address _tokenA, address _tokenB, address _factory) external override onlyOwner {
         require(!initialized, "Pool: already initialized");
-        
+        // --- Checks --- 
+        require(_tokenA != address(0), "Pool: tokenA cannot be zero address");
+        require(_tokenB != address(0), "Pool: tokenB cannot be zero address");
+        require(_factory != address(0), "Pool: factory cannot be zero address");
+
+        // --- Effects --- 
         tokenA = _tokenA;
         tokenB = _tokenB;
         factory = _factory;

--- a/smartcontract/src/PoolFactory.sol
+++ b/smartcontract/src/PoolFactory.sol
@@ -38,15 +38,16 @@ contract PoolFactory is IPoolFactory, Ownable {
             pool := create2(0, add(bytecode, 32), mload(bytecode), salt)
         }
         
-        // Initialize pool
-        Pool(pool).initialize(token0, token1, address(this));
-        
-        // Store pool address in mapping
+        // --- Effects: Update state BEFORE external call ---
         tokenPairToPoolAddress[token0][token1] = pool;
         tokenPairToPoolAddress[token1][token0] = pool;
         allPairs.push(pool);
         
-        emit PoolCreated(token0, token1, pool);
+        // --- Effect: Emit event BEFORE interaction ---
+        emit PoolCreated(token0, token1, pool); 
+        
+        // --- Interaction: Initialize pool AFTER updating state and emitting event ---
+        Pool(pool).initialize(token0, token1, address(this));
     }
     
     // Requirement: Only owner can set fee recipient

--- a/smartcontract/src/interfaces/IDexRouter.sol
+++ b/smartcontract/src/interfaces/IDexRouter.sol
@@ -13,8 +13,9 @@ interface IDexRouter {
         address tokenOut,
         uint256 amountIn,
         uint256 minAmountOut,
-        address recipient
+        address recipient,
+        uint256 deadline
     ) external returns (uint256 amountOut);
 
-    function setForwardingFee(uint256 _fee) external;
+    function setForwardingFee(uint256 _fee) external;   
 } 

--- a/smartcontract/test/router/DexRouter.t.sol
+++ b/smartcontract/test/router/DexRouter.t.sol
@@ -70,7 +70,7 @@ contract DexRouterTest is Test {
         
         // Swapper token1 pour token2
         uint256 balanceBefore = TestToken(token2).balanceOf(USER);
-        uint256 amountOut = router.swap(token1, token2, 100 * 10**18, 1, USER);
+        uint256 amountOut = router.swap(token1, token2, 100 * 10**18, 1, USER, block.timestamp);
         uint256 balanceAfter = TestToken(token2).balanceOf(USER);
         
         // Vérifier que le swap a bien eu lieu
@@ -90,7 +90,7 @@ contract DexRouterTest is Test {
         uint256 usdcBefore = IERC20(USDC).balanceOf(USER);
         
         // Swapper WETH pour USDC via Uniswap
-        uint256 amountOut = router.swap(WETH, USDC, 1 ether, 1, USER);
+        uint256 amountOut = router.swap(WETH, USDC, 1 ether, 1, USER, block.timestamp);
         
         // Solde USDC après
         uint256 usdcAfter = IERC20(USDC).balanceOf(USER);
@@ -112,7 +112,7 @@ contract DexRouterTest is Test {
         uint256 ownerWethBefore = IERC20(WETH).balanceOf(OWNER);
         
         // Swapper WETH pour USDC via Uniswap
-        router.swap(WETH, USDC, 1 ether, 1, USER);
+        router.swap(WETH, USDC, 1 ether, 1, USER, block.timestamp);
         
         // Solde WETH de OWNER après
         uint256 ownerWethAfter = IERC20(WETH).balanceOf(OWNER);


### PR DESCRIPTION
1. Reentrancy Fix in PoolFactory
The createPool function previously contained a reentrancy vulnerability where the external Pool.initialize call occurred before the Factory's state was fully updated. This has been resolved by strictly applying the Checks-Effects-Interactions pattern: state variables (tokenPairToPoolAddress, allPairs) are now modified and the PoolCreated event is emitted (Effects) before the external initialize call (Interaction). This reordering prevents potential attackers from re-entering the function in an inconsistent intermediate state.

2. Event Addition for Fee Changes in DexRouter
The setForwardingFee function allowed the owner to change forwarding fees without on-chain notification. To enhance transparency and auditability, a ForwardingFeeUpdated event is now emitted whenever this fee is modified. This allows users, DApps, and off-chain monitoring tools to easily track changes to this critical parameter.

3. Replacement of block.timestamp with deadline in DexRouter
Using block.timestamp as the deadline for Uniswap calls exposed users to Miner Extractable Value (MEV) risks and potential execution of transactions at stale prices after significant delays. A deadline parameter, supplied by the user via the swap function signature (and its interface), has been introduced. This user-defined deadline is now passed to the external Uniswap call, ensuring the transaction reverts if not executed before the specified time limit, thereby protecting users from unexpected expiration and unfavorable pricing.